### PR TITLE
[UIRTA-4] User can provide custom serializer classes

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -17,5 +17,6 @@ pylint:
     - too-many-arguments
     - unused-argument
     - too-few-public-methods
+    - redefined-outer-name
     - no-else-return
     - too-many-instance-attributes

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -18,5 +18,6 @@ pylint:
     - unused-argument
     - too-few-public-methods
     - redefined-outer-name
+    - too-many-ancestors
     - no-else-return
     - too-many-instance-attributes

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ pip install django-documents-tools
 ```python
     DOCUMENTS_TOOLS = {
         'BASE_CHANGE_SERIALIZER': 'path_to_your_model_serializer',
+        'BASE_CHANGE_VIEWSET': 'path_to_your_model_viewset',
         'BASE_SNAPSHOT_SERIALIZER': 'path_to_your_model_serializer',
+        'BASE_SNAPSHOT_VIEWSET': 'path_to_your_model_viewset',
         'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER': 'path_to_your_model_serializer',
-        'BASE_VIEW_SET': 'path_to_your_model_viewset',
         'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False}
 ```
 
@@ -82,7 +83,7 @@ class Book(Documented):
         return self.title
 ```
 
-## Using custom serializers classes
+## Using custom serializer classes in project
 
 1. Define your custom serializer (must be subclass of corresponding base serializer).
 
@@ -92,7 +93,7 @@ from rest_framework import serializers
 from django_documents_tools.api.serializers import BaseChangeSerializer
 
 
-class CustomChangeSerializerBase(BaseChangeSerializer):
+class BaseCustomChangeSerializer(BaseChangeSerializer):
 
     my_custom_field = serializers.SerializerMethodField()
 
@@ -113,3 +114,58 @@ DOCUMENTS_SETTINGS = {
 ```
 
 3. Now you can easily add, remove and change fields in documented serializers.
+
+## Using custom viewset classes in project
+
+1. Define your custom viewset (must be subclass of corresponding base viewset).
+
+```python
+
+from django_documents_tools.api.viewsets import BaseChangeViewSet
+
+
+class BaseCustomViewSet(BaseChangeViewSet):
+    prefetch_related_fields = ('custom_fields',)
+```
+
+2. Update documents tools settings.
+
+```python
+
+DOCUMENTS_SETTINGS = {
+  'BASE_CHANGE_VIEWSET': 'my_app.ser.CustomChangeViewSetBase'}
+
+```
+
+3. Now you can easily edit viewset attributes.
+
+## Overriding project settings for specific model
+You can use model specific viewset and serializer classes.
+They also must be subclasses of corresponding base classes.
+
+```python
+
+from django_documents_tools.models import (
+    BaseDocumented, Changes, BaseChange, BaseSnapshot)
+
+
+class Documented(BaseDocumented):
+
+    changes = Changes(
+        inherit=True,
+        excluded_fields=('deleted',),
+        change_opts={
+            'bases': (BaseChange,),
+            'base_serializer': 'path.to.change_serializer_class',
+            'base_viewset': 'path.to.change_viewset_class',   
+        },
+        snapshot_opts={
+            'bases': (BaseSnapshot,),
+            'base_serializer': 'path.to.snapshot_serializer_class',
+            'base_viewset': 'path.to.snapshot_viewset_class', 
+            'unit_size_in_days': 1})
+
+    class Meta:
+        abstract = True
+
+```

--- a/README.md
+++ b/README.md
@@ -89,18 +89,18 @@ class Book(Documented):
 ```python
 
 from rest_framework import serializers
-from django_documents_tools.api.serializers import ChangeSerializerBase
+from django_documents_tools.api.serializers import BaseChangeSerializer
 
 
-class CustomChangeSerializerBase(ChangeSerializerBase):
+class CustomChangeSerializerBase(BaseChangeSerializer):
 
     my_custom_field = serializers.SerializerMethodField()
 
     def get_my_custom_field(self, change):
         return 'Extra data'
 
-    class Meta(ChangeSerializerBase.Meta):
-        fields = ChangeSerializerBase.Meta.fields + ('my_custom_field',)
+    class Meta(BaseChangeSerializer.Meta):
+        fields = BaseChangeSerializer.Meta.fields + ('my_custom_field',)
 ```
 
 2. Update documents tools settings.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 ### Quick start
 
 1 Install the library
+
 ```bash
 pip install django-documents-tools
 ```
 
 2 Add `django_documents_tools` to your INSTALLED_APPS setting like this:
+
 ```python
     INSTALLED_APPS = [
         ...
@@ -21,11 +23,14 @@ pip install django-documents-tools
 
 ```python
     DOCUMENTS_TOOLS = {
-        'BASE_SERIALIZER': 'path_to_your_model_serializer',
+        'BASE_CHANGE_SERIALIZER': 'path_to_your_model_serializer',
+        'BASE_SNAPSHOT_SERIALIZER': 'path_to_your_model_serializer',
+        'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER': 'path_to_your_model_serializer',
         'BASE_VIEW_SET': 'path_to_your_model_viewset',
         'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False}
 ```
-  or just use the default values
+
+or just use the default values
 
 4 The basic example how to define a documented object
 
@@ -76,3 +81,35 @@ class Book(Documented):
     def __str__(self):
         return self.title
 ```
+
+## Using custom serializers classes
+
+1. Define your custom serializer (must be subclass of corresponding base serializer).
+
+```python
+
+from rest_framework import serializers
+from django_documents_tools.api.serializers import ChangeSerializerBase
+
+
+class CustomChangeSerializerBase(ChangeSerializerBase):
+
+    my_custom_field = serializers.SerializerMethodField()
+
+    def get_my_custom_field(self, change):
+        return 'Extra data'
+
+    class Meta(ChangeSerializerBase.Meta):
+        fields = ChangeSerializerBase.Meta.fields + ('my_custom_field',)
+```
+
+2. Update documents tools settings.
+
+```python
+
+DOCUMENTS_SETTINGS = {
+  'BASE_CHANGE_SERIALIZER': 'my_app.serializers.CustomChangeSerializerBase'}
+
+```
+
+3. Now you can easily add, remove and change fields in documented serializers.

--- a/django_documents_tools/api/router.py
+++ b/django_documents_tools/api/router.py
@@ -21,7 +21,7 @@ class DocumentedRouter(DefaultRouter):
                 name = _get_viewset_name(snapshot_viewset)  # noqa: protected-access
                 super().register(f'{name}-list', snapshot_viewset, name)
 
-    def register(self, prefix, viewset, basename=None):
+    def register(self, prefix, viewset, basename=None, base_name=None):
         if getattr(viewset, 'allow_changes', True):
             self.register_viewsets(viewset)
-        super().register(prefix, viewset, basename)
+        super().register(prefix, viewset, basename, base_name)

--- a/django_documents_tools/api/router.py
+++ b/django_documents_tools/api/router.py
@@ -21,7 +21,7 @@ class DocumentedRouter(DefaultRouter):
                 name = _get_viewset_name(snapshot_viewset)  # noqa: protected-access
                 super().register(f'{name}-list', snapshot_viewset, name)
 
-    def register(self, prefix, viewset, basename=None, base_name=None):
+    def register(self, prefix, viewset, basename=None):
         if getattr(viewset, 'allow_changes', True):
             self.register_viewsets(viewset)
-        super().register(prefix, viewset, base_name)
+        super().register(prefix, viewset, basename)

--- a/django_documents_tools/api/serializers.py
+++ b/django_documents_tools/api/serializers.py
@@ -8,7 +8,7 @@ from ..settings import tools_settings
 NON_REQUIRED_KWARGS = {'required': False, 'allow_null': True}
 
 
-class ChangeSerializerBase(serializers.ModelSerializer):
+class BaseChangeSerializer(serializers.ModelSerializer):
     document_link = serializers.URLField(default='', allow_blank=True)
     document_fields = serializers.ListField(default=[])
 
@@ -20,7 +20,7 @@ class ChangeSerializerBase(serializers.ModelSerializer):
             'document_fields')
 
 
-class SnapshotSerializerBase(serializers.ModelSerializer):
+class BaseSnapshotSerializer(serializers.ModelSerializer):
     class Meta:
         model = None
         fields = (
@@ -28,7 +28,7 @@ class SnapshotSerializerBase(serializers.ModelSerializer):
             'document_fields', 'history_date')
 
 
-class DocumentedModelLinkSerializer(serializers.ModelSerializer):
+class BaseDocumentedModelLinkSerializer(serializers.ModelSerializer):
     class Meta:
         model = None
         fields = ('_uid', '_type', '_version', 'created', 'updated')
@@ -47,12 +47,12 @@ def get_change_serializer_class(model, serializer_class, allowed_fields=None):
     """
     base = import_string(tools_settings.BASE_CHANGE_SERIALIZER)
 
-    if not issubclass(base, ChangeSerializerBase):
+    if not issubclass(base, BaseChangeSerializer):
         raise Exception(
             f'{base.__name__} must be subclass of '
-            f'{ChangeSerializerBase.__name__}')
+            f'{BaseChangeSerializer.__name__}')
 
-    assert issubclass(base, ChangeSerializerBase)
+    assert issubclass(base, BaseChangeSerializer)
     opts = model._meta  # noqa: protected-access
     documented_field = model._documented_model_field  # noqa: protected-access
     documented_model = serializer_class.Meta.model
@@ -87,10 +87,10 @@ def get_change_serializer_class(model, serializer_class, allowed_fields=None):
 def get_documented_model_serializer(model):
     base = import_string(tools_settings.BASE_DOCUMENTED_MODEL_LINK_SERIALIZER)
 
-    if not issubclass(base, DocumentedModelLinkSerializer):
+    if not issubclass(base, BaseDocumentedModelLinkSerializer):
         raise Exception(
             f'{base.__name__} must be subclass of '
-            f'{DocumentedModelLinkSerializer.__name__}')
+            f'{BaseDocumentedModelLinkSerializer.__name__}')
 
     attrs = {
         'Meta': type(
@@ -103,10 +103,10 @@ def get_documented_model_serializer(model):
 def get_snapshot_serializer(model, change_serializer):
     base = import_string(tools_settings.BASE_SNAPSHOT_SERIALIZER)
 
-    if not issubclass(base, SnapshotSerializerBase):
+    if not issubclass(base, BaseSnapshotSerializer):
         raise Exception(
             f'{base.__name__} must be subclass of '
-            f'{SnapshotSerializerBase.__name__}')
+            f'{BaseSnapshotSerializer.__name__}')
 
     change_model = change_serializer.Meta.model
     documented_model_field = change_model._documented_model_field  # noqa: protected-access

--- a/django_documents_tools/api/serializers.py
+++ b/django_documents_tools/api/serializers.py
@@ -31,7 +31,7 @@ class SnapshotSerializerBase(serializers.ModelSerializer):
 class DocumentedModelLinkSerializer(serializers.ModelSerializer):
     class Meta:
         model = None
-        fields = ('_uid', '_type', '_version')
+        fields = ('_uid', '_type', '_version', 'created', 'updated')
 
 
 def clone_serializer_field(field, **kwargs):

--- a/django_documents_tools/api/serializers.py
+++ b/django_documents_tools/api/serializers.py
@@ -1,5 +1,6 @@
-from django.db import models
 from rest_framework import serializers
+from django.db import models
+from django.utils.module_loading import import_string
 
 from ..settings import tools_settings
 
@@ -7,7 +8,7 @@ from ..settings import tools_settings
 NON_REQUIRED_KWARGS = {'required': False, 'allow_null': True}
 
 
-class ChangeSerializerBase(tools_settings.BASE_SERIALIZER):
+class ChangeSerializerBase(serializers.ModelSerializer):
     document_link = serializers.URLField(default='', allow_blank=True)
     document_fields = serializers.ListField(default=[])
 
@@ -19,7 +20,7 @@ class ChangeSerializerBase(tools_settings.BASE_SERIALIZER):
             'document_fields')
 
 
-class SnapshotSerializerBase(tools_settings.BASE_SERIALIZER):
+class SnapshotSerializerBase(serializers.ModelSerializer):
     class Meta:
         model = None
         fields = (
@@ -27,7 +28,7 @@ class SnapshotSerializerBase(tools_settings.BASE_SERIALIZER):
             'document_fields', 'history_date')
 
 
-class DocumentedModelLinkSerializer(tools_settings.BASE_SERIALIZER):
+class DocumentedModelLinkSerializer(serializers.ModelSerializer):
     class Meta:
         model = None
         fields = ('_uid', '_type', '_version')
@@ -44,11 +45,18 @@ def get_change_serializer_class(model, serializer_class, allowed_fields=None):
         2. Copying explicitly defined fields with args={required=False}
         3. Copying implicitly defined fields with extra_kwargs={required:False}
     """
+    base = import_string(tools_settings.BASE_CHANGE_SERIALIZER)
 
+    if not issubclass(base, ChangeSerializerBase):
+        raise Exception(
+            f'{base.__name__} must be subclass of '
+            f'{ChangeSerializerBase.__name__}')
+
+    assert issubclass(base, ChangeSerializerBase)
     opts = model._meta  # noqa: protected-access
     documented_field = model._documented_model_field  # noqa: protected-access
     documented_model = serializer_class.Meta.model
-    fields = (ChangeSerializerBase.Meta.fields + model._all_documented_fields  # noqa: protected-access
+    fields = (base.Meta.fields + model._all_documented_fields  # noqa: protected-access
               + (documented_field, ))
 
     attrs = {}
@@ -68,37 +76,51 @@ def get_change_serializer_class(model, serializer_class, allowed_fields=None):
     attrs[documented_field] = get_documented_model_serializer(
         documented_model)(**NON_REQUIRED_KWARGS)
     attrs['Meta'] = type(
-        'Meta', (ChangeSerializerBase.Meta,),
+        'Meta', (base.Meta,),
         {'model': model, 'fields': fields, 'read_only_fields': [],
          'extra_kwargs': implicit_fields_extra_kwargs})
 
     name = f'{opts.object_name}Serializer'
-    return type(name, (ChangeSerializerBase,), attrs)
+    return type(name, (base,), attrs)
 
 
 def get_documented_model_serializer(model):
+    base = import_string(tools_settings.BASE_DOCUMENTED_MODEL_LINK_SERIALIZER)
+
+    if not issubclass(base, DocumentedModelLinkSerializer):
+        raise Exception(
+            f'{base.__name__} must be subclass of '
+            f'{DocumentedModelLinkSerializer.__name__}')
+
     attrs = {
         'Meta': type(
-            'Meta', (DocumentedModelLinkSerializer.Meta,),
+            'Meta', (base.Meta,),
             {'model': model, 'ref_name': model._meta.object_name})}  # noqa: protected-access
     name = f'LinkTo{model._meta.object_name}Serializer'  # noqa: protected-access
-    return type(name, (DocumentedModelLinkSerializer, ), attrs)
+    return type(name, (base,), attrs)
 
 
 def get_snapshot_serializer(model, change_serializer):
+    base = import_string(tools_settings.BASE_SNAPSHOT_SERIALIZER)
+
+    if not issubclass(base, SnapshotSerializerBase):
+        raise Exception(
+            f'{base.__name__} must be subclass of '
+            f'{SnapshotSerializerBase.__name__}')
+
     change_model = change_serializer.Meta.model
     documented_model_field = change_model._documented_model_field  # noqa: protected-access
     documented_model = getattr(
         model, change_model._documented_model_field).field.related_model  # noqa: protected-access
-    fields = (SnapshotSerializerBase.Meta.fields
-              + change_model._all_documented_fields  # noqa: protected-access
+    fields = (base.Meta.fields + change_model._all_documented_fields  # noqa: protected-access
               + (documented_model_field, ))
 
     attrs = {
-        'Meta': type('Meta', (SnapshotSerializerBase.Meta,),
+        'Meta': type('Meta', (base.Meta,),
                      {'model': model, 'fields': fields})}
     attrs[documented_model_field] = get_documented_model_serializer(
         documented_model)(**NON_REQUIRED_KWARGS)
 
     name = f'{model._meta.object_name}Serializer'  # noqa: protected-access
-    return type(name, (SnapshotSerializerBase, change_serializer), attrs)
+    bases = (base, change_serializer)
+    return type(name, bases, attrs)

--- a/django_documents_tools/models.py
+++ b/django_documents_tools/models.py
@@ -196,7 +196,8 @@ class Changes:
 
     DEFAULT_CHANGE_OPTS = {
         'bases': (BaseChange,),
-        'bases_viewsets': (),
+        'base_viewset': None,
+        'base_serializer': None,
         'manager_name': 'changes',
         'model_name': None,
         'table_name': None,
@@ -208,7 +209,8 @@ class Changes:
 
     DEFAULT_SNAPSHOT_OPTS = {
         'bases': (BaseSnapshot,),
-        'bases_viewsets': (),
+        'base_serializer': None,
+        'base_viewset': None,
         'unit_size_in_days': None,
         'manager_name': 'snapshots',
         'model_name': None,
@@ -289,7 +291,9 @@ class Changes:
         attrs = {
             '__module__': self.get_module(model, inherited),
             '_documented_excluded_fields': self.excluded_fields,
-            'bases_viewsets': self.change_opts['bases_viewsets']}
+            '_base_viewset': self.change_opts['base_viewset'],
+            '_base_serializer': self.change_opts['base_serializer'],
+        }
         opts = model._meta   # noqa protected-access
 
         primary_field_name = opts.model_name
@@ -335,7 +339,9 @@ class Changes:
         attrs = {
             '__module__': self.get_module(model, inherited),
             'unit_size_in_days': self.snapshot_opts['unit_size_in_days'],
-            'bases_viewsets': self.snapshot_opts['bases_viewsets']}
+            '_base_viewset': self.snapshot_opts['base_viewset'],
+            '_base_serializer': self.snapshot_opts['base_serializer'],
+        }
 
         src_fields = self.get_fields(model)
         fields = self.copy_fields(src_fields)

--- a/django_documents_tools/settings.py
+++ b/django_documents_tools/settings.py
@@ -2,10 +2,18 @@ from collections import ChainMap
 
 from django.conf import settings as django_settings
 from django.test.signals import setting_changed
-from rest_framework import viewsets
 
 
 SETTINGS_NAME = 'DOCUMENTS_TOOLS'
+BASE_SNAPSHOT_SERIALIZER = (
+    'django_documents_tools.api.serializers.BaseSnapshotSerializer')
+BASE_SNAPSHOT_VIEWSET = (
+    'django_documents_tools.api.viewsets.BaseSnapshotViewSet')
+BASE_CHANGE_SERIALIZER = (
+    'django_documents_tools.api.serializers.BaseChangeSerializer')
+BASE_CHANGE_VIEWSET = 'django_documents_tools.api.viewsets.BaseChangeViewSet'
+BASE_DOCUMENTED_MODEL_LINK_SERIALIZER = (
+    'django_documents_tools.api.serializers.BaseDocumentedModelLinkSerializer')
 
 
 def _reload_settings(*args, **kwargs):
@@ -22,14 +30,12 @@ class ToolsSettings(ChainMap): # noqa: too-many-ancestors
 
     DEFAULT_VALUE = object()
     DEFAULT_SETTINGS = {
-        'BASE_SNAPSHOT_SERIALIZER': (
-            'django_documents_tools.api.serializers.BaseSnapshotSerializer'),
-        'BASE_CHANGE_SERIALIZER': (
-            'django_documents_tools.api.serializers.BaseChangeSerializer'),
+        'BASE_SNAPSHOT_SERIALIZER': BASE_SNAPSHOT_SERIALIZER,
+        'BASE_SNAPSHOT_VIEWSET': BASE_SNAPSHOT_VIEWSET,
+        'BASE_CHANGE_SERIALIZER': BASE_CHANGE_SERIALIZER,
+        'BASE_CHANGE_VIEWSET': BASE_CHANGE_VIEWSET,
         'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER': (
-            'django_documents_tools.api.serializers.'
-            'BaseDocumentedModelLinkSerializer'),
-        'BASE_VIEW_SET': viewsets.ModelViewSet,
+            BASE_DOCUMENTED_MODEL_LINK_SERIALIZER),
         'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False}
 
     def __init__(self):

--- a/django_documents_tools/settings.py
+++ b/django_documents_tools/settings.py
@@ -2,8 +2,7 @@ from collections import ChainMap
 
 from django.conf import settings as django_settings
 from django.test.signals import setting_changed
-from django.utils.module_loading import import_string
-from rest_framework import serializers, viewsets
+from rest_framework import viewsets
 
 
 SETTINGS_NAME = 'DOCUMENTS_TOOLS'
@@ -23,7 +22,13 @@ class ToolsSettings(ChainMap): # noqa: too-many-ancestors
 
     DEFAULT_VALUE = object()
     DEFAULT_SETTINGS = {
-        'BASE_SERIALIZER': serializers.ModelSerializer,
+        'BASE_SNAPSHOT_SERIALIZER': (
+            'django_documents_tools.api.serializers.SnapshotSerializerBase'),
+        'BASE_CHANGE_SERIALIZER': (
+            'django_documents_tools.api.serializers.ChangeSerializerBase'),
+        'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER': (
+            'django_documents_tools.api.serializers.'
+            'DocumentedModelLinkSerializer'),
         'BASE_VIEW_SET': viewsets.ModelViewSet,
         'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False}
 
@@ -36,8 +41,6 @@ class ToolsSettings(ChainMap): # noqa: too-many-ancestors
         if value is self.DEFAULT_VALUE:
             raise AttributeError(
                 f"Tools settings object has no attribute '{name}'")
-        elif isinstance(value, str):
-            value = import_string(value)
         return value
 
     def reload_user_settings(self):

--- a/django_documents_tools/settings.py
+++ b/django_documents_tools/settings.py
@@ -23,12 +23,12 @@ class ToolsSettings(ChainMap): # noqa: too-many-ancestors
     DEFAULT_VALUE = object()
     DEFAULT_SETTINGS = {
         'BASE_SNAPSHOT_SERIALIZER': (
-            'django_documents_tools.api.serializers.SnapshotSerializerBase'),
+            'django_documents_tools.api.serializers.BaseSnapshotSerializer'),
         'BASE_CHANGE_SERIALIZER': (
-            'django_documents_tools.api.serializers.ChangeSerializerBase'),
+            'django_documents_tools.api.serializers.BaseChangeSerializer'),
         'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER': (
             'django_documents_tools.api.serializers.'
-            'DocumentedModelLinkSerializer'),
+            'BaseDocumentedModelLinkSerializer'),
         'BASE_VIEW_SET': viewsets.ModelViewSet,
         'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=2.1
-djangorestframework>=3.10.3
+djangorestframework>=3.10.3, <3.11.0
 djangorestframework-filters>=1.0.0.dev0
 django-model-utils>=3.1.2
 psycopg2>=2.7.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import pytest
+
 import django
 from django.conf import settings
 
@@ -49,3 +51,15 @@ def pytest_configure(config):
         )
     )
     django.setup()
+
+
+@pytest.fixture
+def book_change_model():
+    from tests.models import Book
+
+    return Book.changes.model
+
+
+@pytest.fixture
+def book_snapshot_model(book_change_model):
+    return book_change_model._meta.get_field('snapshot').related_model  # noqa: protected-access

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -1,0 +1,11 @@
+import rest_framework_filters as filters
+
+from .models import Book
+
+
+class BookFilter(filters.FilterSet):
+    class Meta:
+        model = Book
+        fields = {
+            'uid': ['exact'],
+        }

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,18 +1,35 @@
+from uuid import uuid4
+
 from django.db import models
 
 from django_documents_tools.models import (
     BaseDocumented, Changes, BaseChange, BaseSnapshot)
 
 
+class BaseChangeModel(BaseChange):
+    uid = models.UUIDField(default=uuid4, primary_key=True)
+
+    class Meta:
+        abstract = True
+
+
+class BaseBaseSnapshotModel(BaseSnapshot):
+    uid = models.UUIDField(default=uuid4, primary_key=True)
+
+    class Meta:
+        abstract = True
+
+
 class Documented(BaseDocumented):
+    uid = models.UUIDField(default=uuid4, primary_key=True)
 
     changes = Changes(
         inherit=True,
         excluded_fields=('deleted',),
         change_opts={
-            'bases': (BaseChange,)},
+            'bases': (BaseChangeModel,)},
         snapshot_opts={
-            'bases': (BaseSnapshot,),
+            'bases': (BaseBaseSnapshotModel,),
             'unit_size_in_days': 1})
 
     class Meta:
@@ -21,6 +38,7 @@ class Documented(BaseDocumented):
 
 class Address(models.Model):
 
+    uid = models.UUIDField(default=uuid4, primary_key=True)
     country = models.CharField(max_length=128)
     city = models.CharField(max_length=128)
     street = models.CharField(max_length=256)
@@ -33,6 +51,7 @@ class Address(models.Model):
 
 class Author(models.Model):
 
+    uid = models.UUIDField(default=uuid4, primary_key=True)
     first_name = models.CharField(max_length=100)
     last_name = models.CharField(max_length=100)
     date_of_birth = models.DateField(null=True, blank=True)
@@ -48,6 +67,7 @@ class Author(models.Model):
 
 class Book(Documented):
 
+    uid = models.UUIDField(default=uuid4, primary_key=True)
     title = models.CharField(max_length=200)
     author = models.ForeignKey('Author', on_delete=models.SET_NULL, null=True)
     summary = models.TextField(max_length=1000, blank=True)

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from django_documents_tools.api.serializers import (
-    ChangeSerializerBase, SnapshotSerializerBase,
-    DocumentedModelLinkSerializer)
+    BaseChangeSerializer, BaseSnapshotSerializer,
+    BaseDocumentedModelLinkSerializer)
 
 from .test_models import Book, Author
 
@@ -21,7 +21,7 @@ class BookSerializer(serializers.ModelSerializer):
         fields = ('id', 'title', 'author', 'summary', 'isbn', 'is_published')
 
 
-class CustomChangeSerializer(ChangeSerializerBase):
+class CustomChangeSerializer(BaseChangeSerializer):
     custom_field = serializers.SerializerMethodField()
 
     @staticmethod
@@ -29,10 +29,10 @@ class CustomChangeSerializer(ChangeSerializerBase):
         return 'Extra'
 
     class Meta:
-        fields = ChangeSerializerBase.Meta.fields + ('custom_field',)
+        fields = BaseChangeSerializer.Meta.fields + ('custom_field',)
 
 
-class CustomSnapshotSerializer(SnapshotSerializerBase):
+class CustomSnapshotSerializer(BaseSnapshotSerializer):
     custom_field = serializers.SerializerMethodField()
 
     @staticmethod
@@ -40,10 +40,10 @@ class CustomSnapshotSerializer(SnapshotSerializerBase):
         return 'Extra'
 
     class Meta:
-        fields = SnapshotSerializerBase.Meta.fields + ('custom_field',)
+        fields = BaseSnapshotSerializer.Meta.fields + ('custom_field',)
 
 
-class CustomDocumentedModelLinkSerializer(DocumentedModelLinkSerializer):
+class CustomDocumentedModelLinkSerializer(BaseDocumentedModelLinkSerializer):
     custom_field = serializers.SerializerMethodField()
 
     @staticmethod
@@ -51,7 +51,8 @@ class CustomDocumentedModelLinkSerializer(DocumentedModelLinkSerializer):
         return 'Extra'
 
     class Meta:
-        fields = DocumentedModelLinkSerializer.Meta.fields + ('custom_field',)
+        fields = BaseDocumentedModelLinkSerializer.Meta.fields + (
+            'custom_field',)
 
 
 class UnknownBookSerializer(serializers.ModelSerializer):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -10,7 +10,7 @@ class AuthorSerializer(serializers.ModelSerializer):
     class Meta:
         model = Author
         fields = (
-            'id', 'first_name', 'last_name', 'date_of_birth', 'date_of_death')
+            'uid', 'first_name', 'last_name', 'date_of_birth', 'date_of_death')
 
 
 class BookSerializer(serializers.ModelSerializer):
@@ -18,7 +18,7 @@ class BookSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Book
-        fields = ('id', 'title', 'author', 'summary', 'isbn', 'is_published')
+        fields = ('uid', 'title', 'author', 'summary', 'isbn', 'is_published')
 
 
 class CustomChangeSerializer(BaseChangeSerializer):
@@ -58,4 +58,4 @@ class CustomDocumentedModelLinkSerializer(BaseDocumentedModelLinkSerializer):
 class UnknownBookSerializer(serializers.ModelSerializer):
     class Meta:
         model = Book
-        fields = ('id', 'title', 'author', 'summary', 'isbn', 'is_published')
+        fields = ('uid', 'title', 'author', 'summary', 'isbn', 'is_published')

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,0 +1,60 @@
+from rest_framework import serializers
+from django_documents_tools.api.serializers import (
+    ChangeSerializerBase, SnapshotSerializerBase,
+    DocumentedModelLinkSerializer)
+
+from .test_models import Book, Author
+
+
+class AuthorSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Author
+        fields = (
+            'id', 'first_name', 'last_name', 'date_of_birth', 'date_of_death')
+
+
+class BookSerializer(serializers.ModelSerializer):
+    author = AuthorSerializer()
+
+    class Meta:
+        model = Book
+        fields = ('id', 'title', 'author', 'summary', 'isbn', 'is_published')
+
+
+class CustomChangeSerializer(ChangeSerializerBase):
+    custom_field = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_custom_field(obj):
+        return 'Extra'
+
+    class Meta:
+        fields = ChangeSerializerBase.Meta.fields + ('custom_field',)
+
+
+class CustomSnapshotSerializer(SnapshotSerializerBase):
+    custom_field = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_custom_field(obj):
+        return 'Extra'
+
+    class Meta:
+        fields = SnapshotSerializerBase.Meta.fields + ('custom_field',)
+
+
+class CustomDocumentedModelLinkSerializer(DocumentedModelLinkSerializer):
+    custom_field = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_custom_field(obj):
+        return 'Extra'
+
+    class Meta:
+        fields = DocumentedModelLinkSerializer.Meta.fields + ('custom_field',)
+
+
+class UnknownBookSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Book
+        fields = ('id', 'title', 'author', 'summary', 'isbn', 'is_published')

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,9 +1,166 @@
+import pytest
+from django.test import override_settings
 from rest_framework.fields import CharField
 
-from django_documents_tools.api.serializers import clone_serializer_field
+from django_documents_tools.api.serializers import (
+    clone_serializer_field, get_change_serializer_class,
+    get_snapshot_serializer, get_documented_model_serializer,
+    ChangeSerializerBase, SnapshotSerializerBase,
+    DocumentedModelLinkSerializer)
+from .serializers import (
+    BookSerializer, CustomChangeSerializer, CustomSnapshotSerializer,
+    CustomDocumentedModelLinkSerializer)
+from .models import Book
+
+
+UNKNOWN_SERIALIZER_PATH = 'tests.serializers.UnknownBookSerializer'
+
+
+@pytest.fixture
+def book_change_model():
+    return Book.changes.model
+
+
+@pytest.fixture
+def book_snapshot_model(book_change_model):
+    return book_change_model._meta.get_field('snapshot').related_model  # noqa: protected-access
 
 
 def test_field_clone():
     src_field = CharField(required=False)
     dst_field = clone_serializer_field(src_field, required=True)
     assert dst_field.required
+
+
+class TestGetChangeSerializerClass:
+    setting_name = 'BASE_CHANGE_SERIALIZER'
+    custom_serializer_path = 'tests.serializers.CustomChangeSerializer'
+    expected_error_msg = (
+        'UnknownBookSerializer must be subclass of ChangeSerializerBase')
+
+    @staticmethod
+    def test_get_default(book_change_model):
+        book_change_serializer = get_change_serializer_class(
+            book_change_model, BookSerializer)
+
+        assert issubclass(book_change_serializer, ChangeSerializerBase)
+        assert book_change_serializer.Meta.fields == (
+            '_uid', '_type', '_version', 'created', 'updated', 'document_name',
+            'document_date', 'document_link', 'document_is_draft',
+            'document_fields', 'title', 'author', 'summary', 'isbn',
+            'is_published', 'book')
+
+    def test_get_custom(self, book_change_model):
+        custom_settings = {
+            self.setting_name: self.custom_serializer_path
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            book_change_serializer = get_change_serializer_class(
+                book_change_model, BookSerializer)
+
+        assert issubclass(book_change_serializer, CustomChangeSerializer)
+        assert book_change_serializer.Meta.fields == (
+            '_uid', '_type', '_version', 'created', 'updated', 'document_name',
+            'document_date', 'document_link', 'document_is_draft',
+            'document_fields', 'custom_field', 'title', 'author', 'summary',
+            'isbn', 'is_published', 'book')
+
+    def test_get_unknown(self, book_change_model):
+        custom_settings = {
+            self.setting_name: UNKNOWN_SERIALIZER_PATH
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            with pytest.raises(Exception) as exc_info:
+                get_change_serializer_class(book_change_model, BookSerializer)
+            assert exc_info.value.args[0] == self.expected_error_msg
+
+
+class TestGetSnapshotSerializerClass:
+    setting_name = 'BASE_SNAPSHOT_SERIALIZER'
+    custom_serializer_path = 'tests.serializers.CustomSnapshotSerializer'
+    expected_error_msg = (
+        'UnknownBookSerializer must be subclass of SnapshotSerializerBase')
+
+    @staticmethod
+    def test_get_default(book_change_model, book_snapshot_model):
+        book_change_serializer = get_change_serializer_class(
+            book_change_model, BookSerializer)
+        book_snapshot_serializer = get_snapshot_serializer(
+            book_snapshot_model, book_change_serializer)
+
+        assert issubclass(book_snapshot_serializer, SnapshotSerializerBase)
+        assert book_snapshot_serializer.Meta.fields == (
+            '_uid', '_type', '_version', 'created', 'updated',
+            'document_fields', 'history_date', 'title', 'author', 'summary',
+            'isbn', 'is_published', 'book')
+
+    def test_get_custom(self, book_change_model, book_snapshot_model):
+        book_change_serializer = get_change_serializer_class(
+            book_change_model, BookSerializer)
+        custom_settings = {
+            self.setting_name: self.custom_serializer_path
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            book_snapshot_serializer = get_snapshot_serializer(
+                book_snapshot_model, book_change_serializer)
+
+        assert issubclass(book_snapshot_serializer, CustomSnapshotSerializer)
+        assert book_snapshot_serializer.Meta.fields == (
+            '_uid', '_type', '_version', 'created', 'updated',
+            'document_fields', 'history_date', 'custom_field', 'title',
+            'author', 'summary', 'isbn', 'is_published', 'book')
+
+    def test_get_unknown(self, book_change_model, book_snapshot_model):
+        book_change_serializer = get_change_serializer_class(
+            book_change_model, BookSerializer)
+        custom_settings = {
+            self.setting_name: UNKNOWN_SERIALIZER_PATH
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            with pytest.raises(Exception) as exc_info:
+                get_snapshot_serializer(
+                    book_snapshot_model, book_change_serializer)
+            assert exc_info.value.args[0] == self.expected_error_msg
+
+
+class TestGetDocumentedModelLinkSerializerClass:
+    setting_name = 'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER'
+    custom_serializer_path = (
+        'tests.serializers.CustomDocumentedModelLinkSerializer')
+    expected_error_msg = (
+        'UnknownBookSerializer must be subclass of '
+        'DocumentedModelLinkSerializer')
+
+    @staticmethod
+    def test_get_default():
+        book_link_serializer = get_documented_model_serializer(Book)
+        assert issubclass(book_link_serializer, DocumentedModelLinkSerializer)
+        assert book_link_serializer.Meta.fields == (
+            '_uid', '_type', '_version', 'created', 'updated')
+
+    def test_get_custom(self):
+        custom_settings = {
+            self.setting_name: self.custom_serializer_path
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            book_link_serializer = get_documented_model_serializer(Book)
+
+        assert issubclass(
+            book_link_serializer, CustomDocumentedModelLinkSerializer)
+        assert book_link_serializer.Meta.fields == (
+            '_uid', '_type', '_version', 'created', 'updated', 'custom_field')
+
+    def test_get_unknown(self, book_change_model):
+        custom_settings = {
+            self.setting_name: UNKNOWN_SERIALIZER_PATH
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            with pytest.raises(Exception) as exc_info:
+                get_documented_model_serializer(Book)
+        assert exc_info.value.args[0] == self.expected_error_msg

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -5,8 +5,8 @@ from rest_framework.fields import CharField
 from django_documents_tools.api.serializers import (
     clone_serializer_field, get_change_serializer_class,
     get_snapshot_serializer, get_documented_model_serializer,
-    ChangeSerializerBase, SnapshotSerializerBase,
-    DocumentedModelLinkSerializer)
+    BaseChangeSerializer, BaseSnapshotSerializer,
+    BaseDocumentedModelLinkSerializer)
 from .serializers import (
     BookSerializer, CustomChangeSerializer, CustomSnapshotSerializer,
     CustomDocumentedModelLinkSerializer)
@@ -36,14 +36,14 @@ class TestGetChangeSerializerClass:
     setting_name = 'BASE_CHANGE_SERIALIZER'
     custom_serializer_path = 'tests.serializers.CustomChangeSerializer'
     expected_error_msg = (
-        'UnknownBookSerializer must be subclass of ChangeSerializerBase')
+        'UnknownBookSerializer must be subclass of BaseChangeSerializer')
 
     @staticmethod
     def test_get_default(book_change_model):
         book_change_serializer = get_change_serializer_class(
             book_change_model, BookSerializer)
 
-        assert issubclass(book_change_serializer, ChangeSerializerBase)
+        assert issubclass(book_change_serializer, BaseChangeSerializer)
         assert book_change_serializer.Meta.fields == (
             '_uid', '_type', '_version', 'created', 'updated', 'document_name',
             'document_date', 'document_link', 'document_is_draft',
@@ -81,7 +81,7 @@ class TestGetSnapshotSerializerClass:
     setting_name = 'BASE_SNAPSHOT_SERIALIZER'
     custom_serializer_path = 'tests.serializers.CustomSnapshotSerializer'
     expected_error_msg = (
-        'UnknownBookSerializer must be subclass of SnapshotSerializerBase')
+        'UnknownBookSerializer must be subclass of BaseSnapshotSerializer')
 
     @staticmethod
     def test_get_default(book_change_model, book_snapshot_model):
@@ -90,7 +90,7 @@ class TestGetSnapshotSerializerClass:
         book_snapshot_serializer = get_snapshot_serializer(
             book_snapshot_model, book_change_serializer)
 
-        assert issubclass(book_snapshot_serializer, SnapshotSerializerBase)
+        assert issubclass(book_snapshot_serializer, BaseSnapshotSerializer)
         assert book_snapshot_serializer.Meta.fields == (
             '_uid', '_type', '_version', 'created', 'updated',
             'document_fields', 'history_date', 'title', 'author', 'summary',
@@ -133,12 +133,13 @@ class TestGetDocumentedModelLinkSerializerClass:
         'tests.serializers.CustomDocumentedModelLinkSerializer')
     expected_error_msg = (
         'UnknownBookSerializer must be subclass of '
-        'DocumentedModelLinkSerializer')
+        'BaseDocumentedModelLinkSerializer')
 
     @staticmethod
     def test_get_default():
         book_link_serializer = get_documented_model_serializer(Book)
-        assert issubclass(book_link_serializer, DocumentedModelLinkSerializer)
+        assert issubclass(
+            book_link_serializer, BaseDocumentedModelLinkSerializer)
         assert book_link_serializer.Meta.fields == (
             '_uid', '_type', '_version', 'created', 'updated')
 

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -1,0 +1,130 @@
+from unittest import mock
+
+import pytest
+from django.test import override_settings
+
+from django_documents_tools.api.viewsets import (
+    get_change_viewset, get_snapshot_viewset, BaseChangeViewSet,
+    BaseSnapshotViewSet)
+from tests.viewsets import (
+    BookViewSet, CustomBookChangeViewSet, CustomBookSnapshotViewSet)
+
+
+UNKNOWN_VIEWSET_PATH = 'tests.viewsets.UnknownBookViewSet'
+
+
+class TestGetChangeViewSet:
+    setting_name = 'BASE_CHANGE_VIEWSET'
+    custom_viewset_path = 'tests.viewsets.CustomBookChangeViewSet'
+    expected_error_msg = (
+        'UnknownBookViewSet must be subclass of BaseChangeViewSet')
+
+    @staticmethod
+    def test_get_default():
+        book_change_viewset = get_change_viewset(BookViewSet)
+
+        assert issubclass(book_change_viewset, BaseChangeViewSet)
+        assert book_change_viewset.allow_history is True
+        assert book_change_viewset.select_related_fields == ('book', 'author')
+        assert book_change_viewset.lookup_field == 'uid'
+        assert book_change_viewset.lookup_url_kwarg == '_uid'
+
+    def test_get_custom(self):
+        custom_settings = {
+            self.setting_name: self.custom_viewset_path
+        }
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            book_change_viewset = get_change_viewset(BookViewSet)
+
+        assert issubclass(book_change_viewset, CustomBookChangeViewSet)
+        assert book_change_viewset.allow_history is True
+        assert book_change_viewset.select_related_fields == ('book', 'author')
+        assert book_change_viewset.lookup_field == 'uid'
+        assert book_change_viewset.lookup_url_kwarg == '_uid'
+        assert book_change_viewset.prefetch_related_fields == ['test']
+
+    def test_get_unknown(self):
+        custom_settings = {
+            self.setting_name: UNKNOWN_VIEWSET_PATH
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            with pytest.raises(Exception) as exc_info:
+                get_change_viewset(BookViewSet)
+            assert exc_info.value.args[0] == self.expected_error_msg
+
+    def test_get_for_model(self, book_change_model):
+        with mock.patch.object(
+                book_change_model, '_base_viewset', self.custom_viewset_path):
+            book_change_viewset = get_change_viewset(BookViewSet)
+
+        assert issubclass(book_change_viewset, CustomBookChangeViewSet)
+        assert book_change_viewset.allow_history is True
+        assert book_change_viewset.select_related_fields == ('book', 'author')
+        assert book_change_viewset.lookup_field == 'uid'
+        assert book_change_viewset.lookup_url_kwarg == '_uid'
+        assert book_change_viewset.prefetch_related_fields == ['test']
+
+
+class TestGetSnapshotViewSet:
+    setting_name = 'BASE_SNAPSHOT_VIEWSET'
+    custom_viewset_path = 'tests.viewsets.CustomBookSnapshotViewSet'
+    expected_error_msg = (
+        'UnknownBookViewSet must be subclass of BaseSnapshotViewSet')
+
+    @staticmethod
+    def test_get_default():
+        book_change_viewset = get_change_viewset(BookViewSet)
+        book_snapshot_viewset = get_snapshot_viewset(
+            book_change_viewset, BookViewSet)
+
+        assert issubclass(book_snapshot_viewset, BaseSnapshotViewSet)
+        assert book_snapshot_viewset.allow_history is False
+        assert book_snapshot_viewset.select_related_fields == (
+            'book', 'author')
+        assert book_snapshot_viewset.lookup_field == 'uid'
+        assert book_snapshot_viewset.lookup_url_kwarg == '_uid'
+
+    def test_get_custom(self):
+        custom_settings = {
+            self.setting_name: self.custom_viewset_path
+        }
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            book_change_viewset = get_change_viewset(BookViewSet)
+            book_snapshot_viewset = get_snapshot_viewset(
+                book_change_viewset, BookViewSet)
+
+        assert issubclass(book_snapshot_viewset, CustomBookSnapshotViewSet)
+        assert book_snapshot_viewset.allow_history is False
+        assert book_snapshot_viewset.select_related_fields == (
+            'book', 'author')
+        assert book_snapshot_viewset.lookup_field == 'uid'
+        assert book_snapshot_viewset.lookup_url_kwarg == '_uid'
+        assert book_snapshot_viewset.prefetch_related_fields == ['test']
+
+    def test_get_unknown(self):
+        custom_settings = {
+            self.setting_name: UNKNOWN_VIEWSET_PATH
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            with pytest.raises(Exception) as exc_info:
+                book_change_viewset = get_change_viewset(BookViewSet)
+                get_snapshot_viewset(book_change_viewset, BookViewSet)
+            assert exc_info.value.args[0] == self.expected_error_msg
+
+    def test_get_for_model(self, book_snapshot_model):
+        with mock.patch.object(
+                book_snapshot_model, '_base_viewset',
+                self.custom_viewset_path):
+            book_change_viewset = get_change_viewset(BookViewSet)
+            book_snapshot_viewset = get_snapshot_viewset(
+                book_change_viewset, BookViewSet)
+
+        assert issubclass(book_snapshot_viewset, CustomBookSnapshotViewSet)
+        assert book_snapshot_viewset.allow_history is False
+        assert book_snapshot_viewset.select_related_fields == (
+            'book', 'author')
+        assert book_snapshot_viewset.lookup_field == 'uid'
+        assert book_snapshot_viewset.lookup_url_kwarg == '_uid'
+        assert book_snapshot_viewset.prefetch_related_fields == ['test']

--- a/tests/viewsets.py
+++ b/tests/viewsets.py
@@ -1,0 +1,37 @@
+from rest_framework.viewsets import ModelViewSet
+
+from django_documents_tools.api.viewsets import (
+    BaseChangeViewSet, BaseSnapshotViewSet)
+
+from .models import Book
+from .serializers import BookSerializer
+from .filters import BookFilter
+
+
+class BookViewSet(ModelViewSet):
+    allow_history = False
+
+    lookup_field = 'uid'
+    lookup_url_kwarg = '_uid'
+    serializer_class = BookSerializer
+    filter_class = BookFilter
+    select_related_fields = ['author']
+    queryset = Book.objects.all()
+
+
+class CustomBookChangeViewSet(BaseChangeViewSet):
+    # Custom viewset attribute
+    prefetch_related_fields = ['test']
+
+
+class CustomBookSnapshotViewSet(BaseSnapshotViewSet):
+    # Custom viewset attribute
+    prefetch_related_fields = ['test']
+
+
+class UnknownBookViewSet(ModelViewSet):
+    lookup_field = 'uid'
+    lookup_url_kwarg = '_uid'
+    serializer_class = BookSerializer
+    filter_class = BookFilter
+    select_related_fields = ['author']


### PR DESCRIPTION
- [x] Import base serializer classes from settings
- [x] Import base viewset classes from settings
- [x] Update documentation
- [x] Add tests for new behavior 
- [x] Silence pytest warnings for [_redefined-outer-name_ ](https://stackoverflow.com/questions/46089480/pytest-fixtures-redefining-name-from-outer-scope-pylint)  (Like in all our [projects](https://github.com/pik-software/django-service-boilerplate/blob/1e6e584e751a48f460edb6b6db0bb55c53a3c200/.prospector.yaml#L19)) 
- [x] Silence pytest warnings for _too-many-ancestors_ (Like in all our projects)
- [x] User can override project level settings for specific model