### PR TITLE
[UIRTA-6] Add change attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,7 @@ class Documented(BaseDocumented):
         change_attachment_opts={
             'bases': (BaseChangeAttachment,),
             'base_serializer': 'path.to.change_attachment_serializer_class',
-            'base_viewset': 'path.to.change_attachment_viewset_class', 
-            'unit_size_in_days': 1
+            'base_viewset': 'path.to.change_attachment_viewset_class',
         },
     )
 

--- a/README.md
+++ b/README.md
@@ -13,22 +13,26 @@ pip install django-documents-tools
 2 Add `django_documents_tools` to your INSTALLED_APPS setting like this:
 
 ```python
-    INSTALLED_APPS = [
-        ...
-        django_documents_tools,
-    ]
+INSTALLED_APPS = [
+    ...,
+    'django_documents_tools',
+]
 ```
 
 3 Configure the settings as you want
 
 ```python
-    DOCUMENTS_TOOLS = {
-        'BASE_CHANGE_SERIALIZER': 'path_to_your_model_serializer',
-        'BASE_CHANGE_VIEWSET': 'path_to_your_model_viewset',
-        'BASE_SNAPSHOT_SERIALIZER': 'path_to_your_model_serializer',
-        'BASE_SNAPSHOT_VIEWSET': 'path_to_your_model_viewset',
-        'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER': 'path_to_your_model_serializer',
-        'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False}
+DOCUMENTS_TOOLS = {
+    'BASE_CHANGE_SERIALIZER': 'path_to_your_model_serializer',
+    'BASE_CHANGE_VIEWSET': 'path_to_your_model_viewset',
+    'BASE_SNAPSHOT_SERIALIZER': 'path_to_your_model_serializer',
+    'BASE_SNAPSHOT_VIEWSET': 'path_to_your_model_viewset',
+    'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER': 'path_to_your_model_serializer',
+    'BASE_CHANGE_ATTACHMENT_SERIALIZER': 'path_to_your_model_serializer',
+    'BASE_CHANGE_ATTACHMENT_VIEWSET': 'path_to_your_model_viewset',
+    'BASE_CHANGE_LINK_SERIALIZER': 'path_to_your_model_serializer',
+    'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False
+}
 ```
 
 or just use the default values
@@ -146,7 +150,7 @@ They also must be subclasses of corresponding base classes.
 ```python
 
 from django_documents_tools.models import (
-    BaseDocumented, Changes, BaseChange, BaseSnapshot)
+    BaseDocumented, Changes, BaseChange, BaseSnapshot, BaseChangeAttachment)
 
 
 class Documented(BaseDocumented):
@@ -163,7 +167,15 @@ class Documented(BaseDocumented):
             'bases': (BaseSnapshot,),
             'base_serializer': 'path.to.snapshot_serializer_class',
             'base_viewset': 'path.to.snapshot_viewset_class', 
-            'unit_size_in_days': 1})
+            'unit_size_in_days': 1
+        },
+        change_attachment_opts={
+            'bases': (BaseChangeAttachment,),
+            'base_serializer': 'path.to.change_attachment_serializer_class',
+            'base_viewset': 'path.to.change_attachment_viewset_class', 
+            'unit_size_in_days': 1
+        },
+    )
 
     class Meta:
         abstract = True

--- a/README.md
+++ b/README.md
@@ -180,3 +180,16 @@ class Documented(BaseDocumented):
         abstract = True
 
 ```
+
+## Signals
+This package provides several signals for use.
+
+## `change_applied` - Send after successful change application.
+Can be used for subscription for specific field updates.
+
+Provided `kwargs`:
+
+- `sender` - _Change_ model
+- `documented_instance` - Documented model instance
+- `change` - Change instance
+- `updated_fields` - Dictionary field -> new value

--- a/django_documents_tools/api/filters.py
+++ b/django_documents_tools/api/filters.py
@@ -1,7 +1,8 @@
 from django.contrib.postgres.fields import ArrayField
 from rest_framework.fields import DateTimeField
 from rest_framework_filters import (
-    FilterSet, RelatedFilter, IsoDateTimeFilter, BaseCSVFilter, AutoFilter)
+    FilterSet, RelatedFilter, IsoDateTimeFilter, BaseCSVFilter, AutoFilter,
+    BooleanFilter)
 
 
 UID_LOOKUPS = ('exact', 'gt', 'gte', 'lt', 'lte', 'in', 'isnull')
@@ -28,6 +29,18 @@ class ChangeFilterBase(FilterSet):
     document_link = AutoFilter(lookups=STRING_LOOKUPS)
     document_is_draft = AutoFilter(lookups=BOOLEAN_LOOKUPS)
     document_fields = ArrayFilter()
+    is_deleted = BooleanFilter(
+        field_name='deleted', method='filter_is_deleted')
+
+    @staticmethod
+    def filter_is_deleted(queryset, name, value):
+        if value is True:
+            return queryset.filter(deleted__isnull=False)
+
+        if value is False:
+            return queryset.filter(deleted__isnull=True)
+
+        return queryset
 
     class Meta:
         model = None
@@ -40,6 +53,18 @@ class ChangeFilterBase(FilterSet):
 class SnapshotFilterBase(FilterSet):
     updated = AutoFilter(lookups=DATE_LOOKUPS)
     history_date = AutoFilter(lookups=DATE_LOOKUPS)
+    is_deleted = BooleanFilter(
+        field_name='deleted', method='filter_is_deleted')
+
+    @staticmethod
+    def filter_is_deleted(queryset, name, value):
+        if value is True:
+            return queryset.filter(deleted__isnull=False)
+
+        if value is False:
+            return queryset.filter(deleted__isnull=True)
+
+        return queryset
 
     class Meta:
         model = None
@@ -62,6 +87,18 @@ class BaseChangeAttachmentFilter(FilterSet):
     updated = AutoFilter(lookups=DATE_LOOKUPS)
     created = AutoFilter(lookups=DATE_LOOKUPS)
     deleted = AutoFilter(lookups=DATE_LOOKUPS)
+    is_deleted = BooleanFilter(
+        field_name='deleted', method='filter_is_deleted')
+
+    @staticmethod
+    def filter_is_deleted(queryset, name, value):
+        if value is True:
+            return queryset.filter(deleted__isnull=False)
+
+        if value is False:
+            return queryset.filter(deleted__isnull=True)
+
+        return queryset
 
     class Meta:
         model = None

--- a/django_documents_tools/api/router.py
+++ b/django_documents_tools/api/router.py
@@ -1,6 +1,7 @@
 from rest_framework.routers import DefaultRouter
 
-from .viewsets import get_change_viewset, get_snapshot_viewset
+from .viewsets import (
+    get_change_viewset, get_snapshot_viewset, get_change_attachment_viewset)
 
 
 def _get_viewset_name(viewset):
@@ -20,6 +21,14 @@ class DocumentedRouter(DefaultRouter):
             if snapshot_viewset:
                 name = _get_viewset_name(snapshot_viewset)  # noqa: protected-access
                 super().register(f'{name}-list', snapshot_viewset, name)
+
+            change_attachment_viewset = get_change_attachment_viewset(
+                change_viewset)
+            if change_attachment_viewset:
+                name = _get_viewset_name(change_attachment_viewset)  # noqa: protected-access
+                super().register(
+                    f'{name}-list', change_attachment_viewset, name)
+
 
     def register(self, prefix, viewset, basename=None, base_name=None):
         if getattr(viewset, 'allow_changes', True):

--- a/django_documents_tools/api/serializers.py
+++ b/django_documents_tools/api/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from django.db import models
 from django.utils.module_loading import import_string
 
+from django_documents_tools.utils import check_subclass
 from ..settings import tools_settings
 
 
@@ -64,11 +65,7 @@ def get_change_serializer_class(model, serializer_class, allowed_fields=None):
     else:
         base_change_serializer = import_string(
             tools_settings.BASE_CHANGE_SERIALIZER)
-
-    if not issubclass(base_change_serializer, BaseChangeSerializer):
-        raise Exception(
-            f'{base_change_serializer.__name__} must be subclass of '
-            f'{BaseChangeSerializer.__name__}')
+    check_subclass(base_change_serializer, BaseChangeSerializer)
 
     opts = model._meta  # noqa: protected-access
     change_attachment_model = model.attachment.field.related_model
@@ -107,11 +104,7 @@ def get_change_serializer_class(model, serializer_class, allowed_fields=None):
 def get_documented_model_serializer(model):
     base = import_string(
         tools_settings.BASE_DOCUMENTED_MODEL_LINK_SERIALIZER)
-
-    if not issubclass(base, BaseDocumentedModelLinkSerializer):
-        raise Exception(
-            f'{base.__name__} must be subclass of '
-            f'{BaseDocumentedModelLinkSerializer.__name__}')
+    check_subclass(base, BaseDocumentedModelLinkSerializer)
 
     attrs = {
         'Meta': type(
@@ -127,11 +120,7 @@ def get_snapshot_serializer(model, change_serializer):
     else:
         base_snapshot_serializer = import_string(
             tools_settings.BASE_SNAPSHOT_SERIALIZER)
-
-    if not issubclass(base_snapshot_serializer, BaseSnapshotSerializer):
-        raise Exception(
-            f'{base_snapshot_serializer.__name__} must be subclass of '
-            f'{BaseSnapshotSerializer.__name__}')
+    check_subclass(base_snapshot_serializer, BaseSnapshotSerializer)
 
     change_model = change_serializer.Meta.model
     documented_model_field = change_model._documented_model_field  # noqa: protected-access
@@ -153,11 +142,7 @@ def get_snapshot_serializer(model, change_serializer):
 
 def get_change_attachment_link_serializer(model):
     base = import_string(tools_settings.BASE_CHANGE_ATTACHMENT_LINK_SERIALIZER)
-
-    if not issubclass(base, BaseChangeAttachmentLinkSerializer):
-        raise Exception(
-            f'{base.__name__} must be subclass of '
-            f'{BaseChangeAttachmentLinkSerializer.__name__}')
+    check_subclass(base, BaseChangeAttachmentLinkSerializer)
 
     meta_opts = {'model': model, 'fields': base.Meta.fields}
     meta = type('Meta', (base.Meta,), meta_opts)
@@ -172,12 +157,8 @@ def get_change_attachment_serializer(model):
     else:
         base_change_attachment_serializer = import_string(
             tools_settings.BASE_CHANGE_ATTACHMENT_SERIALIZER)
-
-    if not issubclass(
-            base_change_attachment_serializer, BaseChangeAttachmentSerializer):
-        raise Exception(
-            f'{base_change_attachment_serializer.__name__} must be subclass of'
-            f' {BaseChangeAttachmentSerializer.__name__}')
+    check_subclass(
+        base_change_attachment_serializer, BaseChangeAttachmentSerializer)
 
     fields = base_change_attachment_serializer.Meta.fields
     meta_opts = {'model': model, 'fields': fields}

--- a/django_documents_tools/api/viewsets.py
+++ b/django_documents_tools/api/viewsets.py
@@ -114,10 +114,10 @@ def get_change_attachment_viewset(change_viewset):
     change_model = change_viewset.serializer_class.Meta.model
     change_filter = change_viewset.filter_class
     change_attachment_model = (
-        change_model._meta.get_field('attachments').related_model)  # noqa: protected-access
+        change_model._meta.get_field('attachment').related_model)  # noqa: protected-access
 
     change_attachment_serializer = get_change_attachment_serializer(
-        change_attachment_model, change_model)
+        change_attachment_model)
 
     if change_attachment_model._base_viewset:  # noqa: protected-access
         base_change_attachment_viewset = import_string(

--- a/django_documents_tools/api/viewsets.py
+++ b/django_documents_tools/api/viewsets.py
@@ -1,8 +1,9 @@
 from rest_framework.viewsets import ModelViewSet
 from django.utils.module_loading import import_string
 
-from .filters import get_change_filter, get_snapshot_filter, \
-    get_change_attachment_filter
+from django_documents_tools.utils import check_subclass
+from .filters import (
+    get_change_filter, get_snapshot_filter, get_change_attachment_filter)
 from .serializers import (
     get_change_serializer_class, get_snapshot_serializer,
     get_change_attachment_serializer)
@@ -59,10 +60,7 @@ def get_change_viewset(documented_viewset):
     else:
         base_change_viewset = import_string(tools_settings.BASE_CHANGE_VIEWSET)
 
-    if not issubclass(base_change_viewset, BaseChangeViewSet):
-        raise Exception(
-            f'{base_change_viewset.__name__} must be subclass of '
-            f'{BaseChangeViewSet.__name__}')
+    check_subclass(base_change_viewset, BaseChangeViewSet)
 
     document_serializer = get_change_serializer_class(
         model, documented_viewset.serializer_class)
@@ -92,10 +90,7 @@ def get_snapshot_viewset(change_viewset, documented_viewset):
         base_snapshot_viewset = import_string(
             tools_settings.BASE_SNAPSHOT_VIEWSET)
 
-    if not issubclass(base_snapshot_viewset, BaseSnapshotViewSet):
-        raise Exception(
-            f'{base_snapshot_viewset.__name__} must be subclass of '
-            f'{BaseSnapshotViewSet.__name__}')
+    check_subclass(base_snapshot_viewset, BaseSnapshotViewSet)
 
     snapshot_serializer = get_snapshot_serializer(
         snapshot_model, change_serializer)
@@ -126,11 +121,7 @@ def get_change_attachment_viewset(change_viewset):
         base_change_attachment_viewset = import_string(
             tools_settings.BASE_CHANGE_ATTACHMENT_VIEWSET)
 
-    if not issubclass(
-            base_change_attachment_viewset, BaseChangeAttachmentViewSet):
-        raise Exception(
-            f'{base_change_attachment_viewset.__name__} must be subclass of '
-            f'{BaseChangeAttachmentViewSet.__name__}')
+    check_subclass(base_change_attachment_viewset, BaseChangeAttachmentViewSet)
 
     change_attachment_filter = get_change_attachment_filter(
         change_attachment_model, change_filter)

--- a/django_documents_tools/manager.py
+++ b/django_documents_tools/manager.py
@@ -77,11 +77,11 @@ class ChangeDescriptor:
 
 
 def setattrs(obj, **attrs):
-    changed = []
+    changed = {}
     for attr, new_value in attrs.items():
         old_value = getattr(obj, attr)
         if old_value != new_value:
-            changed.append(attr)
+            changed[attr] = old_value
             setattr(obj, attr, new_value)
     return changed
 
@@ -315,9 +315,11 @@ class ChangeManager(models.Manager):
             snapshots_qs=snapshots_qs, allowed_latest_date=date)
 
         snapshot = snapshots_slicer.latest_snapshot
+        changed = {}
+
         if snapshot:
-            setattrs(self.instance, **snapshot.state)
-        return self.instance
+            changed = setattrs(self.instance, **snapshot.state)
+        return self.instance, changed
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/django_documents_tools/models.py
+++ b/django_documents_tools/models.py
@@ -209,6 +209,20 @@ class BaseSnapshot(Dated):
 
 class Changes:
 
+    DEFAULT_CHANGE_ATTACHMENT_OPTIONS = {
+        'bases': (BaseChangeAttachment,),
+        'base_viewset': None,
+        'base_serializer': None,
+        'model_name': None,
+        'table_name': None,
+        'verbose_name': None,
+        'verbose_name_template': (
+            '{model._meta.verbose_name} change attachment'),
+        'verbose_name_plural': None,
+        'verbose_name_plural_template': (
+            '{model._meta.verbose_name} change attachments'),
+    }
+
     DEFAULT_CHANGE_OPTS = {
         'bases': (BaseChange,),
         'base_viewset': None,
@@ -237,6 +251,7 @@ class Changes:
     }
     change_model = None
     snapshot_model = None
+    change_attachment_model = None
     module = None
     cls = None
 
@@ -248,7 +263,8 @@ class Changes:
             fields_processors=None,
             app=None,
             change_opts=None,
-            snapshot_opts=None
+            snapshot_opts=None,
+            change_attachment_opts=None,
     ):
         self.fields_processors = fields_processors or FIELDS_PROCESSORS
         self.inherit = inherit
@@ -260,6 +276,10 @@ class Changes:
             **self.DEFAULT_CHANGE_OPTS, **(change_opts or {})}
         self.snapshot_opts = {
             **self.DEFAULT_SNAPSHOT_OPTS, **(snapshot_opts or {})}
+        self.change_attachment_opts = {
+            **self.DEFAULT_CHANGE_ATTACHMENT_OPTIONS,
+            **(change_attachment_opts or {})
+        }
 
         unit_size = self.snapshot_opts.get('unit_size_in_days')
         if not isinstance(unit_size, int) or unit_size < 0:
@@ -280,6 +300,8 @@ class Changes:
 
         self.snapshot_model = self.create_snapshot_model(sender, inherited)
         self.change_model = self.create_change_model(sender, inherited)
+        self.change_attachment_model = self.create_change_attachment_model(
+            sender, inherited)
 
         module = importlib.import_module(self.module)
         if inherited:

--- a/django_documents_tools/models.py
+++ b/django_documents_tools/models.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import importlib
 from typing import List
-from uuid import uuid4
 
 from django.apps import apps
 from django.utils import timezone
@@ -143,7 +142,6 @@ class BaseChangeAttachment(Dated):
         'прикрепленных к документу')
 
     change = None
-    uid = models.UUIDField(default=uuid4, primary_key=True)
     attachment = models.FileField(
         verbose_name=_('вложение'), upload_to=get_change_attachment_path)
 

--- a/django_documents_tools/models.py
+++ b/django_documents_tools/models.py
@@ -199,7 +199,7 @@ class BaseSnapshot(Dated):
         return result
 
     def is_empty(self):
-        return all(v is None for v in self.state.values())
+        return not self.state
 
     def clear_attrs(self):
         for field_name in self.state:

--- a/django_documents_tools/settings.py
+++ b/django_documents_tools/settings.py
@@ -12,6 +12,12 @@ BASE_SNAPSHOT_VIEWSET = (
 BASE_CHANGE_SERIALIZER = (
     'django_documents_tools.api.serializers.BaseChangeSerializer')
 BASE_CHANGE_VIEWSET = 'django_documents_tools.api.viewsets.BaseChangeViewSet'
+BASE_CHANGE_ATTACHMENT_SERIALIZER = (
+    'django_documents_tools.api.serializers.BaseChangeAttachmentSerializer')
+BASE_CHANGE_ATTACHMENT_VIEWSET = (
+    'django_documents_tools.api.viewsets.BaseChangeAttachmentViewSet')
+BASE_CHANGE_LINK_SERIALIZER = (
+    'django_documents_tools.api.serializers.BaseChangeLinkSerializer')
 BASE_DOCUMENTED_MODEL_LINK_SERIALIZER = (
     'django_documents_tools.api.serializers.BaseDocumentedModelLinkSerializer')
 
@@ -34,9 +40,13 @@ class ToolsSettings(ChainMap): # noqa: too-many-ancestors
         'BASE_SNAPSHOT_VIEWSET': BASE_SNAPSHOT_VIEWSET,
         'BASE_CHANGE_SERIALIZER': BASE_CHANGE_SERIALIZER,
         'BASE_CHANGE_VIEWSET': BASE_CHANGE_VIEWSET,
+        'BASE_CHANGE_ATTACHMENT_SERIALIZER': BASE_CHANGE_ATTACHMENT_SERIALIZER,
+        'BASE_CHANGE_ATTACHMENT_VIEWSET': BASE_CHANGE_ATTACHMENT_VIEWSET,
+        'BASE_CHANGE_LINK_SERIALIZER': BASE_CHANGE_LINK_SERIALIZER,
         'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER': (
             BASE_DOCUMENTED_MODEL_LINK_SERIALIZER),
-        'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False}
+        'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False
+    }
 
     def __init__(self):
         user_settings = _get_user_settings()

--- a/django_documents_tools/settings.py
+++ b/django_documents_tools/settings.py
@@ -16,8 +16,9 @@ BASE_CHANGE_ATTACHMENT_SERIALIZER = (
     'django_documents_tools.api.serializers.BaseChangeAttachmentSerializer')
 BASE_CHANGE_ATTACHMENT_VIEWSET = (
     'django_documents_tools.api.viewsets.BaseChangeAttachmentViewSet')
-BASE_CHANGE_LINK_SERIALIZER = (
-    'django_documents_tools.api.serializers.BaseChangeLinkSerializer')
+BASE_CHANGE_ATTACHMENT_LINK_SERIALIZER = (
+    'django_documents_tools.api.serializers.'
+    'BaseChangeAttachmentLinkSerializer')
 BASE_DOCUMENTED_MODEL_LINK_SERIALIZER = (
     'django_documents_tools.api.serializers.BaseDocumentedModelLinkSerializer')
 
@@ -42,7 +43,8 @@ class ToolsSettings(ChainMap): # noqa: too-many-ancestors
         'BASE_CHANGE_VIEWSET': BASE_CHANGE_VIEWSET,
         'BASE_CHANGE_ATTACHMENT_SERIALIZER': BASE_CHANGE_ATTACHMENT_SERIALIZER,
         'BASE_CHANGE_ATTACHMENT_VIEWSET': BASE_CHANGE_ATTACHMENT_VIEWSET,
-        'BASE_CHANGE_LINK_SERIALIZER': BASE_CHANGE_LINK_SERIALIZER,
+        'BASE_CHANGE_ATTACHMENT_LINK_SERIALIZER': (
+            BASE_CHANGE_ATTACHMENT_LINK_SERIALIZER),
         'BASE_DOCUMENTED_MODEL_LINK_SERIALIZER': (
             BASE_DOCUMENTED_MODEL_LINK_SERIALIZER),
         'CREATE_BUSINESS_ENTITY_AFTER_CHANGE_CREATED': False

--- a/django_documents_tools/signals.py
+++ b/django_documents_tools/signals.py
@@ -4,7 +4,7 @@ from django.apps import apps
 from django.db import migrations
 from django.db.migrations.state import StateApps
 from django.db.models.signals import post_migrate
-from django.dispatch import receiver
+from django.dispatch import receiver, Signal
 
 
 def _rename_field(model, old_name, new_name):
@@ -56,3 +56,7 @@ def process_migrate(
             continue
         for operation in migration.operations:
             _process_operation(apps, migration.app_label, operation)
+
+
+change_applied = Signal(  # noqa: pylint=invalid-name
+    providing_args=['documented_instance', 'change', 'updated_fields'])

--- a/django_documents_tools/utils.py
+++ b/django_documents_tools/utils.py
@@ -5,3 +5,9 @@ def get_change_attachment_file_path(instance, file_name):
     app_label = instance._meta.app_label  # noqa: protected-access
     model_name = instance._meta.model_name  # noqa: protected-access
     return os.path.join(app_label, model_name, file_name)
+
+
+def check_subclass(base, original):
+    if not issubclass(base, original):
+        raise Exception(
+            f'{base.__name__} must be subclass of {original.__name__}')

--- a/django_documents_tools/utils.py
+++ b/django_documents_tools/utils.py
@@ -2,5 +2,6 @@ import os
 
 
 def get_change_attachment_path(instance, file_name):
+    app_label = instance._meta.app_label  # noqa: protected-access
     model_name = instance._meta.model_name  # noqa: protected-access
-    return os.path.join(model_name, file_name)
+    return os.path.join(app_label, model_name, file_name)

--- a/django_documents_tools/utils.py
+++ b/django_documents_tools/utils.py
@@ -1,7 +1,7 @@
 import os
 
 
-def get_change_attachment_path(instance, file_name):
+def get_change_attachment_file_path(instance, file_name):
     app_label = instance._meta.app_label  # noqa: protected-access
     model_name = instance._meta.model_name  # noqa: protected-access
     return os.path.join(app_label, model_name, file_name)

--- a/django_documents_tools/utils.py
+++ b/django_documents_tools/utils.py
@@ -1,0 +1,6 @@
+import os
+
+
+def get_change_attachment_path(instance, file_name):
+    model_name = instance._meta.model_name  # noqa: protected-access
+    return os.path.join(model_name, file_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,9 +62,9 @@ def book_change_model():
 
 @pytest.fixture
 def book_snapshot_model(book_change_model):
-    return book_change_model._meta.get_field('snapshot').related_model  # noqa: protected-access
+    return book_change_model.snapshot.field.related_model
 
 
 @pytest.fixture
 def book_change_attachment_model(book_change_model):
-    return book_change_model._meta.get_field('attachments').related_model  # noqa: protected-access
+    return book_change_model.attachment.field.related_model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,3 +63,8 @@ def book_change_model():
 @pytest.fixture
 def book_snapshot_model(book_change_model):
     return book_change_model._meta.get_field('snapshot').related_model  # noqa: protected-access
+
+
+@pytest.fixture
+def book_change_attachment_model(book_change_model):
+    return book_change_model._meta.get_field('attachments').related_model  # noqa: protected-access

--- a/tests/models.py
+++ b/tests/models.py
@@ -25,7 +25,7 @@ class Documented(BaseDocumented):
 
     changes = Changes(
         inherit=True,
-        excluded_fields=('deleted',),
+        excluded_fields=('deleted', 'created', 'updated'),
         change_opts={
             'bases': (BaseChangeModel,)},
         snapshot_opts={

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from django_documents_tools.api.serializers import (
     BaseChangeSerializer, BaseSnapshotSerializer,
-    BaseDocumentedModelLinkSerializer)
+    BaseDocumentedModelLinkSerializer, BaseChangeAttachmentSerializer)
 
 from .test_models import Book, Author
 
@@ -53,6 +53,17 @@ class CustomDocumentedModelLinkSerializer(BaseDocumentedModelLinkSerializer):
     class Meta:
         fields = BaseDocumentedModelLinkSerializer.Meta.fields + (
             'custom_field',)
+
+
+class CustomChangeAttachmentSerializer(BaseChangeAttachmentSerializer):
+    custom_field = serializers.SerializerMethodField()
+
+    @staticmethod
+    def get_custom_field(obj):
+        return 'Extra'
+
+    class Meta:
+        fields = BaseChangeAttachmentSerializer.Meta.fields + ('custom_field',)
 
 
 class UnknownBookSerializer(serializers.ModelSerializer):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -344,3 +344,18 @@ def test_use_initial_snapshot_from_right_documented_object():
     assert change_2.book.title == expected_title
     assert BookChange.objects.count() == 2
     assert Book.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_create_change_attachment(
+        book_change_model, book_change_attachment_model):
+    book = Book.objects.create(title='foo', author=_create_author())
+    book_change = book_change_model.objects.create(
+        book=book, document_is_draft=False, document_date=timezone.now(),
+        document_fields=['title', 'author'], title='bar')
+
+    book_change_attachment = book_change_attachment_model.objects.create(
+        change=book_change, attachment='test.pdf')
+
+    assert book_change_attachment.change == book_change
+    assert book_change_attachment.attachment == 'test.pdf'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -350,12 +350,11 @@ def test_use_initial_snapshot_from_right_documented_object():
 def test_create_change_attachment(
         book_change_model, book_change_attachment_model):
     book = Book.objects.create(title='foo', author=_create_author())
+    book_change_attachment = book_change_attachment_model.objects.create(
+        file='test.pdf')
     book_change = book_change_model.objects.create(
         book=book, document_is_draft=False, document_date=timezone.now(),
-        document_fields=['title', 'author'], title='bar')
+        document_fields=['title', 'author'], title='bar',
+        attachment=book_change_attachment)
 
-    book_change_attachment = book_change_attachment_model.objects.create(
-        change=book_change, attachment='test.pdf')
-
-    assert book_change_attachment.change == book_change
-    assert book_change_attachment.attachment == 'test.pdf'
+    assert book_change.attachment == book_change_attachment

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -7,11 +7,12 @@ from rest_framework.fields import CharField
 from django_documents_tools.api.serializers import (
     clone_serializer_field, get_change_serializer_class,
     get_snapshot_serializer, get_documented_model_serializer,
-    BaseChangeSerializer, BaseSnapshotSerializer,
-    BaseDocumentedModelLinkSerializer)
+    get_change_attachment_serializer, BaseChangeSerializer,
+    BaseSnapshotSerializer, BaseDocumentedModelLinkSerializer,
+    BaseChangeAttachmentSerializer)
 from .serializers import (
     BookSerializer, CustomChangeSerializer, CustomSnapshotSerializer,
-    CustomDocumentedModelLinkSerializer)
+    CustomDocumentedModelLinkSerializer, CustomChangeAttachmentSerializer)
 from .models import Book
 
 
@@ -187,3 +188,69 @@ class TestGetDocumentedModelLinkSerializerClass:
             with pytest.raises(Exception) as exc_info:
                 get_documented_model_serializer(Book)
         assert exc_info.value.args[0] == self.expected_error_msg
+
+
+class TestGetChangeAttachmentSerializerClass:
+    setting_name = 'BASE_CHANGE_ATTACHMENT_SERIALIZER'
+    custom_serializer_path = (
+        'tests.serializers.CustomChangeAttachmentSerializer')
+    expected_error_msg = (
+        'UnknownBookSerializer must be subclass of '
+        'BaseChangeAttachmentSerializer')
+
+    @staticmethod
+    def test_get_default(book_change_model, book_change_attachment_model):
+        book_change_attachment_serializer = get_change_attachment_serializer(
+            book_change_attachment_model, book_change_model)
+
+        assert issubclass(
+            book_change_attachment_serializer, BaseChangeAttachmentSerializer)
+        assert book_change_attachment_serializer.Meta.fields == (
+            '_uid', '_type', '_version', 'created', 'updated', 'change',
+            'attachment')
+
+    def test_get_custom(self, book_change_model, book_change_attachment_model):
+        custom_settings = {
+            self.setting_name: self.custom_serializer_path
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            book_change_attachment_serializer = (
+                get_change_attachment_serializer(
+                    book_change_attachment_model, book_change_model))
+
+        assert issubclass(
+            book_change_attachment_serializer,
+            CustomChangeAttachmentSerializer)
+        assert book_change_attachment_serializer.Meta.fields == (
+            '_uid', '_type', '_version', 'created', 'updated', 'change',
+            'attachment', 'custom_field')
+
+    def test_get_unknown(
+            self, book_change_model, book_change_attachment_model):
+        custom_settings = {
+            self.setting_name: UNKNOWN_SERIALIZER_PATH
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            with pytest.raises(Exception) as exc_info:
+                get_change_attachment_serializer(
+                    book_change_attachment_model, book_change_model)
+            assert exc_info.value.args[0] == self.expected_error_msg
+
+    def test_get_for_model(
+            self, book_change_model, book_change_attachment_model):
+
+        with mock.patch.object(
+                book_change_attachment_model, '_base_serializer',
+                self.custom_serializer_path):
+            book_change_attachment_serializer = (
+                get_change_attachment_serializer(
+                    book_change_attachment_model, book_change_model))
+
+        assert issubclass(
+            book_change_attachment_serializer,
+            CustomChangeAttachmentSerializer)
+        assert book_change_attachment_serializer.Meta.fields == (
+            '_uid', '_type', '_version', 'created', 'updated',
+            'change', 'attachment', 'custom_field')

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -40,8 +40,8 @@ class TestGetChangeSerializerClass:
         assert book_change_serializer.Meta.fields == (
             '_uid', '_type', '_version', 'created', 'updated', 'document_name',
             'document_date', 'document_link', 'document_is_draft',
-            'document_fields', 'title', 'author', 'summary', 'isbn',
-            'is_published', 'book')
+            'document_fields', 'attachment', 'title', 'author', 'summary',
+            'isbn', 'is_published', 'book')
 
     def test_get_custom(self, book_change_model):
         custom_settings = {
@@ -56,8 +56,8 @@ class TestGetChangeSerializerClass:
         assert book_change_serializer.Meta.fields == (
             '_uid', '_type', '_version', 'created', 'updated', 'document_name',
             'document_date', 'document_link', 'document_is_draft',
-            'document_fields', 'custom_field', 'title', 'author', 'summary',
-            'isbn', 'is_published', 'book')
+            'document_fields', 'attachment', 'custom_field', 'title', 'author',
+            'summary', 'isbn', 'is_published', 'book')
 
     def test_get_unknown(self, book_change_model):
         custom_settings = {
@@ -80,8 +80,8 @@ class TestGetChangeSerializerClass:
         assert book_change_serializer.Meta.fields == (
             '_uid', '_type', '_version', 'created', 'updated', 'document_name',
             'document_date', 'document_link', 'document_is_draft',
-            'document_fields', 'custom_field', 'title', 'author', 'summary',
-            'isbn', 'is_published', 'book')
+            'document_fields', 'attachment', 'custom_field', 'title', 'author',
+            'summary', 'isbn', 'is_published', 'book')
 
 
 class TestGetSnapshotSerializerClass:
@@ -199,58 +199,52 @@ class TestGetChangeAttachmentSerializerClass:
         'BaseChangeAttachmentSerializer')
 
     @staticmethod
-    def test_get_default(book_change_model, book_change_attachment_model):
+    def test_get_default(book_change_attachment_model):
         book_change_attachment_serializer = get_change_attachment_serializer(
-            book_change_attachment_model, book_change_model)
+            book_change_attachment_model)
 
         assert issubclass(
             book_change_attachment_serializer, BaseChangeAttachmentSerializer)
         assert book_change_attachment_serializer.Meta.fields == (
-            '_uid', '_type', '_version', 'created', 'updated', 'change',
-            'attachment')
+            '_uid', '_type', '_version', 'created', 'updated', 'file')
 
-    def test_get_custom(self, book_change_model, book_change_attachment_model):
+    def test_get_custom(self, book_change_attachment_model):
         custom_settings = {
             self.setting_name: self.custom_serializer_path
         }
 
         with override_settings(DOCUMENTS_TOOLS=custom_settings):
             book_change_attachment_serializer = (
-                get_change_attachment_serializer(
-                    book_change_attachment_model, book_change_model))
+                get_change_attachment_serializer(book_change_attachment_model))
 
         assert issubclass(
             book_change_attachment_serializer,
             CustomChangeAttachmentSerializer)
         assert book_change_attachment_serializer.Meta.fields == (
-            '_uid', '_type', '_version', 'created', 'updated', 'change',
-            'attachment', 'custom_field')
+            '_uid', '_type', '_version', 'created', 'updated', 'file',
+            'custom_field')
 
-    def test_get_unknown(
-            self, book_change_model, book_change_attachment_model):
+    def test_get_unknown(self, book_change_attachment_model):
         custom_settings = {
             self.setting_name: UNKNOWN_SERIALIZER_PATH
         }
 
         with override_settings(DOCUMENTS_TOOLS=custom_settings):
             with pytest.raises(Exception) as exc_info:
-                get_change_attachment_serializer(
-                    book_change_attachment_model, book_change_model)
+                get_change_attachment_serializer(book_change_attachment_model)
             assert exc_info.value.args[0] == self.expected_error_msg
 
-    def test_get_for_model(
-            self, book_change_model, book_change_attachment_model):
+    def test_get_for_model(self, book_change_attachment_model):
 
         with mock.patch.object(
                 book_change_attachment_model, '_base_serializer',
                 self.custom_serializer_path):
             book_change_attachment_serializer = (
-                get_change_attachment_serializer(
-                    book_change_attachment_model, book_change_model))
+                get_change_attachment_serializer(book_change_attachment_model))
 
         assert issubclass(
             book_change_attachment_serializer,
             CustomChangeAttachmentSerializer)
         assert book_change_attachment_serializer.Meta.fields == (
-            '_uid', '_type', '_version', 'created', 'updated',
-            'change', 'attachment', 'custom_field')
+            '_uid', '_type', '_version', 'created', 'updated', 'file',
+            'custom_field')

--- a/tests/test_viewsets.py
+++ b/tests/test_viewsets.py
@@ -4,10 +4,11 @@ import pytest
 from django.test import override_settings
 
 from django_documents_tools.api.viewsets import (
-    get_change_viewset, get_snapshot_viewset, BaseChangeViewSet,
-    BaseSnapshotViewSet)
+    get_change_viewset, get_snapshot_viewset, get_change_attachment_viewset,
+    BaseChangeViewSet, BaseSnapshotViewSet, BaseChangeAttachmentViewSet)
 from tests.viewsets import (
-    BookViewSet, CustomBookChangeViewSet, CustomBookSnapshotViewSet)
+    BookViewSet, CustomBookChangeViewSet, CustomBookSnapshotViewSet,
+    CustomBookChangeAttachmentViewSet)
 
 
 UNKNOWN_VIEWSET_PATH = 'tests.viewsets.UnknownBookViewSet'
@@ -128,3 +129,72 @@ class TestGetSnapshotViewSet:
         assert book_snapshot_viewset.lookup_field == 'uid'
         assert book_snapshot_viewset.lookup_url_kwarg == '_uid'
         assert book_snapshot_viewset.prefetch_related_fields == ['test']
+
+
+class TestGetChangeAttachmentViewSet:
+    setting_name = 'BASE_CHANGE_ATTACHMENT_VIEWSET'
+    custom_viewset_path = 'tests.viewsets.CustomBookChangeAttachmentViewSet'
+    expected_error_msg = (
+        'UnknownBookViewSet must be subclass of BaseChangeAttachmentViewSet')
+
+    @staticmethod
+    def test_get_default():
+        book_change_viewset = get_change_viewset(BookViewSet)
+        book_change_attachment_viewset = get_change_attachment_viewset(
+            book_change_viewset)
+
+        assert issubclass(
+            book_change_attachment_viewset, BaseChangeAttachmentViewSet)
+        assert book_change_attachment_viewset.allow_history is True
+        assert book_change_attachment_viewset.select_related_fields == (
+            'change',)
+        assert book_change_attachment_viewset.lookup_field == 'uid'
+        assert book_change_attachment_viewset.lookup_url_kwarg == '_uid'
+
+    def test_get_custom(self):
+        custom_settings = {
+            self.setting_name: self.custom_viewset_path
+        }
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            book_change_viewset = get_change_viewset(BookViewSet)
+            book_change_attachment_viewset = get_change_attachment_viewset(
+                book_change_viewset)
+
+        assert issubclass(
+            book_change_attachment_viewset, CustomBookChangeAttachmentViewSet)
+        assert book_change_attachment_viewset.allow_history is True
+        assert book_change_attachment_viewset.select_related_fields == (
+            'change',)
+        assert book_change_attachment_viewset.lookup_field == 'uid'
+        assert book_change_attachment_viewset.lookup_url_kwarg == '_uid'
+        assert book_change_attachment_viewset.prefetch_related_fields == [
+            'test']
+
+    def test_get_unknown(self):
+        custom_settings = {
+            self.setting_name: UNKNOWN_VIEWSET_PATH
+        }
+
+        with override_settings(DOCUMENTS_TOOLS=custom_settings):
+            with pytest.raises(Exception) as exc_info:
+                book_change_viewset = get_change_viewset(BookViewSet)
+                get_change_attachment_viewset(book_change_viewset)
+            assert exc_info.value.args[0] == self.expected_error_msg
+
+    def test_get_for_model(self, book_change_attachment_model):
+        with mock.patch.object(
+                book_change_attachment_model, '_base_viewset',
+                self.custom_viewset_path):
+            book_change_viewset = get_change_viewset(BookViewSet)
+            book_change_attachment_viewset = get_change_attachment_viewset(
+                book_change_viewset)
+
+        assert issubclass(
+            book_change_attachment_viewset, CustomBookChangeAttachmentViewSet)
+        assert book_change_attachment_viewset.allow_history is True
+        assert book_change_attachment_viewset.select_related_fields == (
+            'change',)
+        assert book_change_attachment_viewset.lookup_field == 'uid'
+        assert book_change_attachment_viewset.lookup_url_kwarg == '_uid'
+        assert book_change_attachment_viewset.prefetch_related_fields == [
+            'test']

--- a/tests/viewsets.py
+++ b/tests/viewsets.py
@@ -1,7 +1,7 @@
 from rest_framework.viewsets import ModelViewSet
 
 from django_documents_tools.api.viewsets import (
-    BaseChangeViewSet, BaseSnapshotViewSet)
+    BaseChangeViewSet, BaseSnapshotViewSet, BaseChangeAttachmentViewSet)
 
 from .models import Book
 from .serializers import BookSerializer
@@ -25,6 +25,11 @@ class CustomBookChangeViewSet(BaseChangeViewSet):
 
 
 class CustomBookSnapshotViewSet(BaseSnapshotViewSet):
+    # Custom viewset attribute
+    prefetch_related_fields = ['test']
+
+
+class CustomBookChangeAttachmentViewSet(BaseChangeAttachmentViewSet):
     # Custom viewset attribute
     prefetch_related_fields = ['test']
 


### PR DESCRIPTION
Добавил возможность прикреплять вложения (`ChangeAttachment`) к документам. Вложение - это модель для хранения пользовательских файлов для документов. Модель, сериализатор и вьюсет для вложений можно настраивать глобально на проект или для конкретной документируемой модели.

- [x] Обновил документацию
- [x] Добавил тесты
- [x] Пофиксил `included_fields` (настройка не работала для `editable` полей)
- [x] Пофиксил метод `is_empty()` в снапшоте (ложное срабатывание при `None` значениях)
- [x] Добавил сигнал `change_applied` из версии _housing_.
- [x] Добавил фильтр `is_deleted` для `Change`, `ChangeAttachment` и `Snapshot`