### PR TITLE
[UIRTA-9] Add documented field validation

### DIFF
--- a/django_documents_tools/api/serializers.py
+++ b/django_documents_tools/api/serializers.py
@@ -11,7 +11,7 @@ NON_REQUIRED_KWARGS = {'required': False, 'allow_null': True}
 
 class BaseChangeSerializer(serializers.ModelSerializer):
     document_link = serializers.URLField(default='', allow_blank=True)
-    document_fields = serializers.ListField(default=[])
+    document_fields = serializers.ListField(allow_empty=False, required=True)
 
     def validate(self, attrs):
         # Ensure that new documented obj will be in correct state.

--- a/django_documents_tools/models.py
+++ b/django_documents_tools/models.py
@@ -16,7 +16,7 @@ from .manager import ChangeDescriptor, SnapshotDescriptor
 from .exceptions import (
     BusinessEntityCreationIsNotAllowedError, ChangesAreNotCreatedYetError)
 from .settings import tools_settings as t_settings
-from .utils import get_change_attachment_file_path
+from .utils import get_change_attachment_file_path, LimitedChoicesValidator
 
 
 LOGGER = logging.getLogger(__name__)
@@ -85,8 +85,7 @@ class BaseChange(Dated):
     document_link = models.URLField(
         _('Ссылка на документ'), default='', blank=True)
     document_is_draft = models.BooleanField(_('Черновик'), default=True)
-    document_fields = ArrayField(
-        models.CharField(_('Атрибуты'), max_length=255), default=list)
+    document_fields = None
 
     def __str__(self):
         return f'{self.pk} - {self.document_name}'
@@ -374,6 +373,9 @@ class Changes:
             self.change_attachment_model, on_delete=models.SET_NULL,
             related_name='change', null=True, blank=True,
             verbose_name=attachment_title)  # noqa: protected-access
+        attrs['document_fields'] = ArrayField(
+            models.CharField(_('Атрибуты'), max_length=255), default=list,
+            validators=[LimitedChoicesValidator(documented_fields)])
         base_meta = {
             'ordering': ('-document_date',),
             'get_latest_by': 'document_date'}

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name='django-documents-tools',
     author='pik-software',
     author_email='no-reply@pik-software.ru',
-    version='0.3.2',
+    version='0.3.3',
     license='BSD-3-Clause',
     url='https://github.com/pik-software/documents-tools',
     install_requires=REQUIREMENTS,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.test import override_settings
 from django_documents_tools.exceptions import (
@@ -358,3 +359,58 @@ def test_create_change_attachment(
         attachment=book_change_attachment)
 
     assert book_change.attachment == book_change_attachment
+
+
+@pytest.mark.django_db
+class TestValidateDocumentedFields:
+
+    @staticmethod
+    def test_empty(book_change_model):
+        book_change = book_change_model(
+            document_is_draft=False, document_date=timezone.now(),
+            document_fields=[], document_name='test')
+
+        with pytest.raises(ValidationError) as exc_info:
+            book_change.full_clean()
+
+        assert str(exc_info.value.args[0]) == (
+            "{'document_fields': [ValidationError(['This field cannot "
+            "be blank.'])]}")
+
+    @staticmethod
+    def test_none(book_change_model):
+        book_change = book_change_model(
+            document_is_draft=False, document_date=timezone.now(),
+            document_fields=None, document_name='test')
+
+        with pytest.raises(ValidationError) as exc_info:
+            book_change.full_clean()
+
+        assert str(exc_info.value.args[0]) == (
+            "{'document_fields': [ValidationError(['This field cannot "
+            "be null.'])]}")
+
+    @staticmethod
+    def test_duplicated(book_change_model):
+        book_change = book_change_model(
+            document_is_draft=False, document_date=timezone.now(),
+            document_fields=['title', 'author', 'title'], document_name='test')
+
+        with pytest.raises(ValidationError) as exc_info:
+            book_change.full_clean()
+
+        assert str(exc_info.value.args[0]) == (
+            "{'document_fields': [ValidationError(['Found duplicate field "
+            "`title`.'])]}")
+
+    @staticmethod
+    def test_unknown(book_change_model):
+        book_change = book_change_model(
+            document_is_draft=False, document_date=timezone.now(),
+            document_fields=['title', 'author', 'foo'], document_name='test')
+
+        with pytest.raises(ValidationError) as exc_info:
+            book_change.full_clean()
+
+        assert str(exc_info.value.args[0]) == (
+            "{'document_fields': [ValidationError(['Unknown field `foo`.'])]}")


### PR DESCRIPTION
Сделал поле `document_fields` обязательным для документа и добавил валидацию содержимого.

См. баг [тикет](https://jira.pik-software.ru/secure/RapidBoard.jspa?rapidView=158&view=detail&selectedIssue=UIRTA-9)