### PR TITLE
[UIRTA-9] Добавил фильтрацию документируемых полей при обновлении снапшота

### DIFF
--- a/django_documents_tools/models.py
+++ b/django_documents_tools/models.py
@@ -101,10 +101,17 @@ class BaseChange(Dated):
     class Meta:
         abstract = True
 
+    def get_documented_fields(self):
+        return [
+            field for field in self.document_fields
+            if field in self._all_documented_fields
+        ]
+
     def get_snapshot_changes(self):
-        return {field: getattr(self, field)
-                for field in self.document_fields
-                if field in self._all_documented_fields}
+        return {
+            field: getattr(self, field)
+            for field in self.get_documented_fields()
+        }
 
     def get_changes(self):
         return self.get_snapshot_changes()
@@ -193,9 +200,10 @@ class BaseSnapshot(Dated):
     @property
     def document_fields_from_changes(self):
         result = set()
-        doc_fields = self.changes.values_list('document_fields', flat=True)
-        for fields in doc_fields.all():
-            result.update(fields)
+
+        for change in self.changes.all():
+            result.update(change.get_documented_fields())
+
         return result
 
     def is_empty(self):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name='django-documents-tools',
     author='pik-software',
     author_email='no-reply@pik-software.ru',
-    version='0.3.3',
+    version='0.3.4',
     license='BSD-3-Clause',
     url='https://github.com/pik-software/documents-tools',
     install_requires=REQUIREMENTS,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name='django-documents-tools',
     author='pik-software',
     author_email='no-reply@pik-software.ru',
-    version='0.3.2',
+    version='0.3.3',
     license='BSD-3-Clause',
     url='https://github.com/pik-software/documents-tools',
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
При [обновлении одного снапшота на основе другого](https://github.com/pik-software/django-documents-tools/blob/master/django_documents_tools/manager.py#L53) используется [общий список документируемых полей](https://github.com/pik-software/django-documents-tools/blob/master/django_documents_tools/models.py#L194) из документов. Если в одном из документов указаны неправильные документируемые поля - это приводит к ошибке.