### PR TITLE
[UIRTA-15] Fix change document date

### DIFF
--- a/django_documents_tools/manager.py
+++ b/django_documents_tools/manager.py
@@ -108,7 +108,6 @@ class SnapshotCalculator:
         snapshot = self._snapshots_qs.first()
         if snapshot and not changes:
             snapshot.deleted = timezone.now()
-            snapshot.clear_attrs()
             snapshot.save()
             return snapshot
 
@@ -264,7 +263,7 @@ class SnapshotsSlicer:
                     changes_qs=changes_qs,
                     rel_to_documented_obj=self._rel_to_documented_obj)
                 snapshot = snapshot_calculator.calculate_snapshot()
-                if snapshot and not snapshot.is_empty():
+                if snapshot and not snapshot.deleted:
                     self._snapshots.append(snapshot)
             else:
                 snapshot = snapshots_qs.filter(deleted__isnull=True).first()

--- a/django_documents_tools/models.py
+++ b/django_documents_tools/models.py
@@ -140,7 +140,7 @@ class BaseChange(Dated):
 
             applicable_date = timezone.now().date()
             new_documented.changes.apply_to_object(date=applicable_date)
-            new_documented.save()
+            new_documented.save(apply_documents=False)
             self.refresh_from_db()
 
 
@@ -204,13 +204,6 @@ class BaseSnapshot(Dated):
             result.update(change.get_documented_fields())
 
         return result
-
-    def is_empty(self):
-        return not self.state
-
-    def clear_attrs(self):
-        for field_name in self.state:
-            setattr(self, field_name, None)
 
 
 class Changes:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,3 +4,4 @@ prospector==1.1.5
 pylint==2.1.1
 ipython==7.10.1
 pytest-django==3.7.0
+freezegun==0.3.15


### PR DESCRIPTION
При изменении даты документа больше чем на `unit_size_in_days` удаляется снапшот за предыдущую дату (если на старую дату больше нет документов). После удаления и затирания снапшот все равно применяется к объекту, т.к проходит проверку на пустоту (первый баг). После применения снапшота вызывается метод `.save()` у документируемого объекта - это приводит ко второму вызову метода `changes.apply_to_object()` (второй баг), но уже с правильным снапшотом. При таком поведении второй баг маскирует первый. Ошибку можно заметить если использовать сигнал `change_applied`, при первом вызове. В нем будет невалидный документируемый объект.

Итого:

1. Убрал повторный вызов `changes.apply_to_object()` при изменении документа
2. Убрал очистку снапшота перед удалением (пустой снапшот нужен только для проверки?)
3. Заменил проверку снапшота на пустоту на проверку на удаление
