### PR TITLE
[UIRTA-26] Переместил применение документа в post_save сигнал

### DIFF
--- a/django_documents_tools/models.py
+++ b/django_documents_tools/models.py
@@ -123,6 +123,12 @@ class BaseChange(Dated):
         new_documented.save(apply_documents=False)
         return new_documented
 
+    def save(self, *args, **kwargs):  # noqa: pylint==arguments-differ
+        super().save(*args, **kwargs)
+
+        # We are using `post_save` signal for document processing.
+        # See `finalize` method in `Changes` for more info.
+
 
 class BaseChangeAttachment(Dated):
     _help_text = _(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name='django-documents-tools',
     author='pik-software',
     author_email='no-reply@pik-software.ru',
-    version='0.3.4',
+    version='0.3.5',
     license='BSD-3-Clause',
     url='https://github.com/pik-software/documents-tools',
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
После сохранения документа отрабатывает [код](https://github.com/pik-software/django-documents-tools/blob/fix-change-document-date/django_documents_tools/models.py#L130) для его применения. При таком подходе пользователь библиотеки не может использовать сигнал `post_save` у документа т.к. код сигнала будет выполняться между сохранением в базу и логикой обработки документов. Перемещение кода в сигнал `post_save` позволит разработчикам использовать его в своем коде т.к. обработчики сигналов выполняются в порядке подключения.