### PR TITLE
 [HOUSING-531] Fix snapshot related model filter

### DIFF
--- a/django_documents_tools/api/viewsets.py
+++ b/django_documents_tools/api/viewsets.py
@@ -94,7 +94,7 @@ def get_snapshot_viewset(change_viewset, documented_viewset):
 
     snapshot_serializer = get_snapshot_serializer(
         snapshot_model, change_serializer)
-    snapshot_filter = get_snapshot_filter(snapshot_model, change_viewset)
+    snapshot_filter = get_snapshot_filter(snapshot_model, documented_viewset)
 
     attrs = {'serializer_class': snapshot_serializer,
              'filter_class': snapshot_filter,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name='django-documents-tools',
     author='pik-software',
     author_email='no-reply@pik-software.ru',
-    version='0.3.8',
+    version='0.3.9',
     license='BSD-3-Clause',
     url='https://github.com/pik-software/documents-tools',
     install_requires=REQUIREMENTS,


### PR DESCRIPTION
При создании `SnapshotFilter` создавался фильтр для вложенной модели с `pk_field`. Заменил создание вложенного фильтра для документированной модели на получение его из документированного вьюсета.